### PR TITLE
0.1.2+1

### DIFF
--- a/splitio/CHANGELOG.md
+++ b/splitio/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 0.1.2+1
+
 * Added exports for models.
 
 ## 0.1.2

--- a/splitio/CHANGELOG.md
+++ b/splitio/CHANGELOG.md
@@ -1,4 +1,7 @@
-# 0.1.2
+## 0.1.2+1
+* Added exports for models.
+
+## 0.1.2
 
 * Migrated to federated structure.
 * Added support for Impression Listener.
@@ -7,7 +10,7 @@
 * Added support for manager methods.
 * Added support for linking native factory.
 
-# 0.1.1
+## 0.1.1
 
 Minor fixes.
 

--- a/splitio/lib/split_client.dart
+++ b/splitio/lib/split_client.dart
@@ -1,4 +1,3 @@
-import 'package:splitio_platform_interface/split_result.dart';
 import 'package:splitio_platform_interface/splitio_platform_interface.dart';
 
 abstract class SplitClient {

--- a/splitio/lib/splitio.dart
+++ b/splitio/lib/splitio.dart
@@ -6,6 +6,8 @@ import 'package:splitio_platform_interface/splitio_platform_interface.dart';
 export 'package:splitio/split_client.dart';
 export 'package:splitio_platform_interface/split_configuration.dart';
 export 'package:splitio_platform_interface/split_impression.dart';
+export 'package:splitio_platform_interface/split_result.dart';
+export 'package:splitio_platform_interface/split_sync_config.dart';
 export 'package:splitio_platform_interface/split_view.dart';
 
 typedef ClientReadinessCallback = void Function(SplitClient splitClient);

--- a/splitio/pubspec.yaml
+++ b/splitio/pubspec.yaml
@@ -1,6 +1,6 @@
 name: splitio
 description: Official plugin for split.io, the platform for controlled rollouts, which serves features to your users via a Split feature flag to manage your complete customer experience.
-version: 0.1.2
+version: 0.1.2+1
 homepage: https://split.io/
 repository: https://github.com/splitio/flutter-sdk-plugin/tree/main/splitio/
 

--- a/splitio/test/splitio_platform_stub.dart
+++ b/splitio/test/splitio_platform_stub.dart
@@ -1,8 +1,4 @@
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
-import 'package:splitio_platform_interface/split_configuration.dart';
-import 'package:splitio_platform_interface/split_impression.dart';
-import 'package:splitio_platform_interface/split_result.dart';
-import 'package:splitio_platform_interface/split_view.dart';
 import 'package:splitio_platform_interface/splitio_platform_interface.dart';
 
 class SplitioPlatformStub


### PR DESCRIPTION
# Flutter plugin

## What did you accomplish?

- Added missing exports for some models.

Note for reviewers: The `+1` means patch for version `0.x.x` (see [here](https://dart.dev/tools/pub/versioning#semantic-versions))