### PR TITLE
Consumer ProGuard rules

### DIFF
--- a/splitio/CHANGELOG.md
+++ b/splitio/CHANGELOG.md
@@ -1,12 +1,12 @@
-## 0.1.2+2
+## 0.1.2+2 (Dec 7, 2022)
 
 Added consumer ProGuard rules for Android.
 
-## 0.1.2+1
+## 0.1.2+1 (Sep 14, 2022)
 
 Added exports for models.
 
-## 0.1.2
+## 0.1.2 (Sep 13, 2022)
 
 * Migrated to federated structure.
 * Added support for Impression Listener.
@@ -15,11 +15,11 @@ Added exports for models.
 * Added support for manager methods.
 * Added support for linking native factory.
 
-## 0.1.1
+## 0.1.1 (Aug 19, 2022)
 
 Minor fixes.
 
-## 0.1.0
+## 0.1.0 (Aug 3, 2022)
 
 Initial release.
 

--- a/splitio/CHANGELOG.md
+++ b/splitio/CHANGELOG.md
@@ -1,6 +1,10 @@
+## 0.1.2+2
+
+Added consumer ProGuard rules for Android.
+
 ## 0.1.2+1
 
-* Added exports for models.
+Added exports for models.
 
 ## 0.1.2
 

--- a/splitio/pubspec.yaml
+++ b/splitio/pubspec.yaml
@@ -1,6 +1,6 @@
 name: splitio
 description: Official plugin for split.io, the platform for controlled rollouts, which serves features to your users via a Split feature flag to manage your complete customer experience.
-version: 0.1.2+1
+version: 0.1.2+2
 homepage: https://split.io/
 repository: https://github.com/splitio/flutter-sdk-plugin/tree/main/splitio/
 
@@ -19,7 +19,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  splitio_android: ^0.1.2
+  splitio_android: ^0.1.2+1
   splitio_ios: ^0.1.2
   splitio_platform_interface: ^1.0.0
 

--- a/splitio_android/CHANGELOG.md
+++ b/splitio_android/CHANGELOG.md
@@ -1,7 +1,7 @@
-## 0.1.2+1
+## 0.1.2+1 (Dec 7, 2022)
 
 Added Consumer ProGuard rules.
 
-## 0.1.2
+## 0.1.2 (Aug 13, 2022)
 
 Splits from `splitio` as federated implementation.

--- a/splitio_android/CHANGELOG.md
+++ b/splitio_android/CHANGELOG.md
@@ -1,3 +1,7 @@
-# 0.1.2
+## 0.1.2+1
+
+Added Consumer ProGuard rules.
+
+## 0.1.2
 
 Splits from `splitio` as federated implementation.

--- a/splitio_android/android/build.gradle
+++ b/splitio_android/android/build.gradle
@@ -31,6 +31,8 @@ android {
 
     defaultConfig {
         minSdkVersion 16
+
+        consumerProguardFiles 'split-proguard-rules.pro'
     }
 
     dependencies {

--- a/splitio_android/android/split-proguard-rules.pro
+++ b/splitio_android/android/split-proguard-rules.pro
@@ -1,0 +1,15 @@
+# Please include these rules in your project
+# in order to make Split code work properly when
+# using proguard
+-keep class io.split.android.client.dtos.* { *; }
+-keep class io.split.android.client.storage.db.** { *; }
+-keep public class io.split.android.client.service.sseclient.SseJwtToken.** { *; }
+-keep public class io.split.android.client.service.sseclient.SseAuthToken.** { *; }
+-keep public class io.split.android.client.service.sseclient.SseAuthenticationResponse.** { *; }
+-keep class io.split.android.client.service.sseclient.notifications.** { *; }
+-keepattributes Signature
+-keep class com.google.gson.reflect.TypeToken { *; }
+-keep class * extends com.google.gson.reflect.TypeToken
+-keepclassmembers,allowobfuscation class * {
+ @com.google.gson.annotations.SerializedName <fields>;
+}

--- a/splitio_android/pubspec.yaml
+++ b/splitio_android/pubspec.yaml
@@ -1,7 +1,7 @@
 name: splitio_android
 description: The official Android implementation of splitio Flutter plugin.
 repository: https://github.com/splitio/flutter-sdk-plugin/tree/main/splitio_android
-version: 0.1.2
+version: 0.1.2+1
 
 environment:
   sdk: ">=2.16.2 <3.0.0"

--- a/splitio_ios/CHANGELOG.md
+++ b/splitio_ios/CHANGELOG.md
@@ -1,3 +1,3 @@
-# 0.1.2
+# 0.1.2 (Aug 13, 2022)
 
 Splits from `splitio` as federated implementation.

--- a/splitio_platform_interface/CHANGELOG.md
+++ b/splitio_platform_interface/CHANGELOG.md
@@ -1,3 +1,3 @@
-# 1.0.0
+# 1.0.0 (Aug 13, 2022)
 
 Initial release.


### PR DESCRIPTION
# Flutter plugin

## What did you accomplish?

- Added the consumer ProGuard rules for Android. This is related to https://github.com/splitio/flutter-sdk-plugin/issues/55

- Updated `splitio_android` to `0.1.2+1` and frontend package version to `0.1.2+2`.