### PR TITLE
Update SplitResult.toString to display null values differently

### DIFF
--- a/splitio_platform_interface/lib/split_result.dart
+++ b/splitio_platform_interface/lib/split_result.dart
@@ -13,8 +13,8 @@ class SplitResult {
   String toString() {
     return '{"treatment": "' +
         treatment +
-        '", config: "' +
-        (config ?? 'null') +
-        '"}';
+        '", config: ' +
+        (config != null ? '"$config"' : 'null') +
+        '}';
   }
 }


### PR DESCRIPTION
When a `SplitResult` is converted into a string (such as when printing or running in debugger) and the config value is `null`, the previous implementation would display `"null"` as if it were a `String` which is confusing, because it is `null`.

# Flutter plugin

## What did you accomplish?

Less confusing string representation of `SplitResult`.

## How do we test the changes introduced in this PR?

Get split results with no config, see them printed, convert them to strings in your Flutter app or view it in debugger.

## Extra Notes

This would make me think that I need to handle `"null"` strings instead of `null` values.

![Screenshot 2023-09-22 at 14 49 35](https://github.com/splitio/flutter-sdk-plugin/assets/9061239/f6c6cc34-b311-41ce-85be-7f03e42dfc8f)
